### PR TITLE
Database clean up on uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Perform the necessary steps to uninstall Koko Analytics
+ * Perform the necessary steps to completely uninstall Koko Analytics
  */
 
 // if uninstall.php is not called by WordPress, die
 if (!defined('WP_UNINSTALL_PLUGIN')) die;
 
-// delete wp options
+// delete wp-options
 delete_option("koko_analytics_settings");
 delete_option("koko_analytics_version");
 
@@ -14,6 +14,8 @@ delete_option("koko_analytics_version");
 global $wpdb;
 $wpdb->query(
     "DROP TABLE IF EXISTS
-    {$wpdb->prefix}koko_analytics_site_stats, {$wpdb->prefix}koko_analytics_post_stats,
-    {$wpdb->prefix}koko_analytics_referrer_stats, {$wpdb->prefix}koko_analytics_referrer_urls"
+    {$wpdb->prefix}koko_analytics_site_stats,
+    {$wpdb->prefix}koko_analytics_post_stats,
+    {$wpdb->prefix}koko_analytics_referrer_stats,
+    {$wpdb->prefix}koko_analytics_referrer_urls"
 );

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Perform the necessary steps to uninstall Koko Analytics
+ */
+
+// if uninstall.php is not called by WordPress, die
+if (!defined('WP_UNINSTALL_PLUGIN')) die;
+
+// delete wp options
+delete_option("koko_analytics_settings");
+delete_option("koko_analytics_version");
+
+// drop koko tables
+global $wpdb;
+$wpdb->query(
+    "DROP TABLE IF EXISTS
+    {$wpdb->prefix}koko_analytics_site_stats, {$wpdb->prefix}koko_analytics_post_stats,
+    {$wpdb->prefix}koko_analytics_referrer_stats, {$wpdb->prefix}koko_analytics_referrer_urls"
+);


### PR DESCRIPTION
Personally, I really dislike that when deleting plugins, they keep their data in the database, and I have to clean them up manually.

From the [WordPress Plugin Handbook](https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/), I found out that the file `uninstall.php` gets called when uninstalling the plugin. There is the "hook" method of doing the very same thing, but personally I find it better to have the respective code in a different file (I don't really mind, though).

I have seen some plugins that allow the users prevent the data from being removed on uninstall (normally with a checkbox), but I find this setting a little redundant: even if the user is deactivating the plugin to test something, the `uninstall.php` script only runs when deleting the plugin. What are your thoughts about this?

I suggest that Koko Analytics clean its data after deletion 🙂