### PR TITLE
Update class-admin.php

### DIFF
--- a/src/class-admin.php
+++ b/src/class-admin.php
@@ -34,7 +34,9 @@ class Admin
 		switch ( $suffix ) {
 			case 'index.php':
 				wp_enqueue_script( 'koko-analytics-dashboard-widget', plugins_url( '/assets/dist/js/dashboard-widget.js', KOKO_ANALYTICS_PLUGIN_FILE ), array( 'wp-i18n' ), KOKO_ANALYTICS_VERSION, true );
-				wp_set_script_translations( 'koko-analytics-dashboard-widget', 'koko-analytics' );
+				if ( function_exists( 'wp_set_script_translations' ) ) {
+					wp_set_script_translations( 'koko-analytics-dashboard-widget', 'koko-analytics' );
+				}
 				wp_localize_script(
 					'koko-analytics-dashboard-widget',
 					'koko_analytics',
@@ -53,7 +55,9 @@ class Admin
 				$colors = $this->get_colors();
 
 				wp_enqueue_script( 'koko-analytics-admin', plugins_url( 'assets/dist/js/admin.js', KOKO_ANALYTICS_PLUGIN_FILE ), array( 'wp-i18n' ), KOKO_ANALYTICS_VERSION, true );
-				wp_set_script_translations( 'koko-analytics-admin', 'koko-analytics' );
+				if ( function_exists( 'wp_set_script_translations' ) ) {
+					wp_set_script_translations( 'koko-analytics-admin', 'koko-analytics' );
+				}
 				wp_localize_script('koko-analytics-admin', 'koko_analytics', array(
 					'root'          => rest_url(),
 					'nonce'         => wp_create_nonce( 'wp_rest' ),


### PR DESCRIPTION
wp_set_script_translations() is introduced in WP 5.0. Surrounding it with an if statement to make it backward compatible.
Users with WP below 5.0 will see a white screen of death on dashboard. 