### PR TITLE
Skip empty lines in  buffer file during aggregation

### DIFF
--- a/src/class-aggregator.php
+++ b/src/class-aggregator.php
@@ -97,7 +97,11 @@ class Aggregator {
 		$referrer_stats = array();
 
 		while ( ( $line = fgets( $file_handle, 1024 ) ) !== false ) {
-			$line            = rtrim( $line );
+			$line = rtrim( $line );
+			if ( empty( $line ) ) {
+				continue;
+			}
+
 			$p               = explode( ',', $line );
 			$post_id         = (int) $p[0];
 			$new_visitor     = (int) $p[1];


### PR DESCRIPTION
It seems like it's possible that `fgets()` can read an empty line, probably the last one. Too avoid some PHP notices I added this sanity check.

The notices are:

> PHP Notice:  Undefined offset: 1
> PHP Notice:  Undefined offset: 2
> PHP Notice:  Undefined offset: 3