### PR TITLE
Make use of date-fns for date range presets

### DIFF
--- a/assets/src/js/util/date-presets.js
+++ b/assets/src/js/util/date-presets.js
@@ -1,5 +1,22 @@
 import { __ } from '@wordpress/i18n'
-const startOfWeek = parseInt(window.koko_analytics.start_of_week)
+import {
+  endOfMonth,
+  endOfQuarter,
+  endOfToday,
+  endOfWeek,
+  endOfYear,
+  endOfYesterday,
+  startOfDay,
+  startOfMonth,
+  startOfQuarter,
+  startOfToday,
+  startOfWeek,
+  startOfYear,
+  startOfYesterday,
+  sub
+} from 'date-fns'
+
+const monday = 1
 
 export default [
   {
@@ -10,9 +27,8 @@ export default [
     key: 'today',
     label: __('Today', 'koko-analytics'),
     dates: () => {
-      const now = new Date()
-      const startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0)
-      const endDate = new Date(now.getFullYear(), now.getMonth(), startDate.getDate(), 23, 59, 59)
+      const startDate = startOfToday()
+      const endDate = endOfToday()
       return { startDate, endDate }
     }
   },
@@ -20,9 +36,8 @@ export default [
     key: 'yesterday',
     label: __('Yesterday', 'koko-analytics'),
     dates: () => {
-      const now = new Date()
-      const startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1, 0, 0, 0)
-      const endDate = new Date(now.getFullYear(), now.getMonth(), startDate.getDate(), 23, 59, 59)
+      const startDate = startOfYesterday()
+      const endDate = endOfYesterday()
       return { startDate, endDate }
     }
   },
@@ -31,13 +46,8 @@ export default [
     label: __('This week', 'koko-analytics'),
     dates: () => {
       const now = new Date()
-      let d = now.getDate() - now.getDay() + startOfWeek
-      if (now.getDay() < startOfWeek) {
-        d = d - 7
-      }
-
-      const startDate = new Date(now.getFullYear(), now.getMonth(), d, 0, 0, 0)
-      const endDate = new Date(now.getFullYear(), startDate.getMonth(), startDate.getDate() + 6, 23, 59, 59)
+      const startDate = startOfWeek(now, { weekStartsOn: monday })
+      const endDate = endOfWeek(now, { weekStartsOn: monday })
       return { startDate, endDate }
     }
   },
@@ -45,14 +55,10 @@ export default [
     key: 'last_week',
     label: __('Last week', 'koko-analytics'),
     dates: () => {
-      const now = new Date()
-      let d = now.getDate() - now.getDay() + startOfWeek
-      if (now.getDay() < startOfWeek) {
-        d = d - 7
-      }
-
-      const startDate = new Date(now.getFullYear(), now.getMonth(), d - 7, 0, 0, 0)
-      const endDate = new Date(now.getFullYear(), startDate.getMonth(), startDate.getDate() + 6, 23, 59, 59)
+      const today = new Date()
+      const lastWeekToday = sub(today, { weeks: 1 })
+      const startDate = startOfWeek(lastWeekToday, { weekStartsOn: monday })
+      const endDate = endOfWeek(lastWeekToday, { weekStartsOn: monday })
       return { startDate, endDate }
     }
   },
@@ -60,9 +66,10 @@ export default [
     key: 'last_28_days',
     label: __('Last 28 days', 'koko-analytics'),
     dates: () => {
-      const now = new Date()
-      const startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 27, 0, 0, 0)
-      const endDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59)
+      const today = new Date()
+      const twentySevenDaysAgo = sub(today, { days: 27 })
+      const startDate = startOfDay(twentySevenDaysAgo)
+      const endDate = endOfToday()
       return { startDate, endDate }
     }
   },
@@ -70,9 +77,9 @@ export default [
     key: 'this_month',
     label: __('This month', 'koko-analytics'),
     dates: () => {
-      const now = new Date()
-      const startDate = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0)
-      const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + 1, 0, 23, 59, 59)
+      const today = new Date()
+      const startDate = startOfMonth(today)
+      const endDate = endOfMonth(today)
       return { startDate, endDate }
     }
   },
@@ -80,9 +87,10 @@ export default [
     key: 'last_month',
     label: __('Last month', 'koko-analytics'),
     dates: () => {
-      const now = new Date()
-      const startDate = new Date(now.getFullYear(), now.getMonth() - 1, 1, 0, 0, 0)
-      const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + 1, 0, 23, 59, 59)
+      const today = new Date()
+      const lastMonthToday = sub(today, { months: 1 })
+      const startDate = startOfMonth(lastMonthToday)
+      const endDate = endOfMonth(lastMonthToday)
       return { startDate, endDate }
     }
   },
@@ -90,9 +98,9 @@ export default [
     key: 'this_quarter',
     label: __('This quarter', 'koko-analytics'),
     dates: () => {
-      const now = new Date()
-      const startDate = new Date(now.getFullYear(), (Math.ceil((now.getMonth() + 1) / 3) - 1) * 3, 1, 0, 0, 0)
-      const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + 3, 0, 23, 59, 59)
+      const today = new Date()
+      const startDate = startOfQuarter(today)
+      const endDate = endOfQuarter(today)
       return { startDate, endDate }
     }
   },
@@ -100,9 +108,11 @@ export default [
     key: 'last_quarter',
     label: __('Last quarter', 'koko-analytics'),
     dates: () => {
-      const now = new Date()
-      const startDate = new Date(now.getFullYear(), (Math.ceil((now.getMonth() + 1) / 3) - 1) * 3 - 3, 1, 0, 0, 0)
-      const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + 3, 0, 23, 59, 59)
+      const today = new Date()
+      const startOfThisQuarter = startOfQuarter(today)
+      const insideLastQuarter = sub(startOfThisQuarter, { weeks: 1 })
+      const startDate = startOfQuarter(insideLastQuarter)
+      const endDate = endOfQuarter(insideLastQuarter)
       return { startDate, endDate }
     }
   },
@@ -110,9 +120,9 @@ export default [
     key: 'this_year',
     label: __('This year', 'koko-analytics'),
     dates: () => {
-      const now = new Date()
-      const startDate = new Date(now.getFullYear(), 0, 1, 0, 0, 0)
-      const endDate = new Date(startDate.getFullYear(), 12, 0, 23, 59, 59)
+      const today = new Date()
+      const startDate = startOfYear(today)
+      const endDate = endOfYear(today)
       return { startDate, endDate }
     }
   },
@@ -120,9 +130,10 @@ export default [
     key: 'last_year',
     label: __('Last year', 'koko-analytics'),
     dates: () => {
-      const now = new Date()
-      const startDate = new Date(now.getFullYear() - 1, 0, 1, 0, 0, 0)
-      const endDate = new Date(startDate.getFullYear(), 12, 0, 23, 59, 59)
+      const today = new Date()
+      const lastYearToday = sub(today, { years: 1 })
+      const startDate = startOfYear(lastYearToday)
+      const endDate = endOfYear(lastYearToday)
       return { startDate, endDate }
     }
   }

--- a/assets/src/js/util/date-presets.js
+++ b/assets/src/js/util/date-presets.js
@@ -17,6 +17,7 @@ import {
 } from 'date-fns'
 
 const monday = 1
+const firstDayOfTheWeek = parseInt(window.koko_analytics.start_of_week) || monday
 
 export default [
   {
@@ -46,8 +47,8 @@ export default [
     label: __('This week', 'koko-analytics'),
     dates: () => {
       const now = new Date()
-      const startDate = startOfWeek(now, { weekStartsOn: monday })
-      const endDate = endOfWeek(now, { weekStartsOn: monday })
+      const startDate = startOfWeek(now, { weekStartsOn: firstDayOfTheWeek })
+      const endDate = endOfWeek(now, { weekStartsOn: firstDayOfTheWeek })
       return { startDate, endDate }
     }
   },
@@ -57,8 +58,12 @@ export default [
     dates: () => {
       const today = new Date()
       const lastWeekToday = sub(today, { weeks: 1 })
-      const startDate = startOfWeek(lastWeekToday, { weekStartsOn: monday })
-      const endDate = endOfWeek(lastWeekToday, { weekStartsOn: monday })
+      const startDate = startOfWeek(lastWeekToday, {
+        weekStartsOn: firstDayOfTheWeek
+      })
+      const endDate = endOfWeek(lastWeekToday, {
+        weekStartsOn: firstDayOfTheWeek
+      })
       return { startDate, endDate }
     }
   },


### PR DESCRIPTION
This PR makes use of the helpers included in date-fns (which already is a dependency) for generating date preset ranges. The reason I've made this contribution is that the current implementation seems to be flawed:
Today (2nd of January 2022) I've selected "current week" in the dashboard, which resulted in the date range _2021-12-27_ until _2023-01-02_, which is obiously incorrect.
Instead of trying to fix this one error, I simply replaced the custom implementation with date-fns helpers. This makes it less error-prone in my eyes, since date-fns is a very well-established library.