### PR TITLE
Add filter to allow users to disable cron warning message

### DIFF
--- a/src/class-admin.php
+++ b/src/class-admin.php
@@ -102,6 +102,11 @@ class Admin
 		// detect issues with WP Cron event not running
 		// it should run every minute, so if it didn't run in 10 minutes there is most likely something wrong
 		$next_scheduled = wp_next_scheduled( 'koko_analytics_aggregate_stats' );
+
+		if ( has_filter( 'koko_analytics_disable_cron_warning' ) ) {
+			return apply_filters( 'koko_analytics_disable_cron_warning', $next_scheduled );
+		}
+
 		return $next_scheduled !== false && $next_scheduled > ( time() - HOUR_IN_SECONDS );
 	}
 


### PR DESCRIPTION
Whenever users disable the WP Cron this message is shown:
'There seems to be an issue with your site's WP Cron configuration that prevents Koko Analytics from automatically processing your statistics. If you're not sure what this is about, please ask your webhost to look into this.'

This PR adds an extra check to allow users to turn off the cron warning message programmatically. To do so, users just need to add a `koko_analytics_disable_cron_warning` filter that returns `true`. For convenience the `$next_scheduled` value is passed through in case the user wants to perform some verification.

```php
add_filter( 'koko_analytics_disable_cron_warning', function( $next_scheduled ) {
	// perform verification using next scheduled cron event or simply return true/false
	return true;
} );
```

The `is_cron_event_working` method name seems to be a bit off with this change. Open to suggestions or improvements.
