### PR TITLE
Allow users to disable the optimized endpoint

### DIFF
--- a/code-snippets/README.md
+++ b/code-snippets/README.md
@@ -15,3 +15,7 @@ Only if you're still not seeing this file, try the manual approach described bel
 
 #### How to manually install the optimized tracking endpoint?
 Go to the settings page in your Koko Analytics dashboard. Follow the instructions at the bottom of the page to manually install the optimized tracking endpoint.
+
+### How to disable the optimized tracking endpoint?
+
+In your `wp-config.php`, set `define('KOKO_ANALYTICS_USE_CUSTOM_ENDPOINT', false);`

--- a/src/class-endpoint-installer.php
+++ b/src/class-endpoint-installer.php
@@ -8,6 +8,10 @@ class Endpoint_Installer {
 	}
 
 	private function install_optimized_endpoint_file() {
+		if ( defined( 'KOKO_ANALYTICS_USE_CUSTOM_ENDPOINT' ) && KOKO_ANALYTICS_USE_CUSTOM_ENDPOINT === false) {
+			return;
+		}
+
 		/* Do nothing if running Multisite (because Multisite has separate uploads directory per site) */
 		if ( is_multisite() ) {
 			return false;

--- a/src/functions.php
+++ b/src/functions.php
@@ -173,5 +173,9 @@ function get_realtime_pageview_count( $since = null ) {
 }
 
 function using_custom_endpoint() {
+	if ( defined( 'KOKO_ANALYTICS_USE_CUSTOM_ENDPOINT' ) ) {
+		return KOKO_ANALYTICS_USE_CUSTOM_ENDPOINT;
+	}
+
 	return get_option( 'koko_analytics_use_custom_endpoint', false );
 }


### PR DESCRIPTION
I tried enabling this plugin on WP Engine, and it does not work. There's a 500 error from the optimized tracking endpoint and I couldn't find any error log inside the WP Engine admin panel. [At least one more person had this issue](https://wordpress.org/support/topic/not-working-on-wpengine-2/).

I then tried to disable the optimized tracking endpoint but found it was [removed for some reason in an earlier commit](https://github.com/ibericode/koko-analytics/commit/9044480a725edd2f378237957f21d4a4eeb45ba7).

I tried without the optimized endpoint (by modifying the code) and it worked fine on WP Engine. So here's a PR to bring back the functionality so that WP Engine users can use the plugin.

PS. It would of course be nice to figure out the root cause of the issue, but considering WP Engines exotic environment, this workaround is better than nothing.