### PR TITLE
Add WP Engine instructions

### DIFF
--- a/code-snippets/wpengine-buffer-file.php
+++ b/code-snippets/wpengine-buffer-file.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WP Engine does not allow the creation of .php files using file_put_content which Koko uses, so we change
+ * WP Engine does not allow the creation of .php files using file_put_contents which Koko uses, so we change
  * it to use a file with .txt extension. Make sure to change SECRET-NAME to something unique
  * so that nobody can see your temporary visitor logs. Additionally, make sure this is added to your themes functions.php
  * BEFORE you activate Koko analytics. If Koko has previously been activated, you need to delete the file /koko-analytics-collect.php

--- a/code-snippets/wpengine-buffer-file.php
+++ b/code-snippets/wpengine-buffer-file.php
@@ -10,3 +10,4 @@
  * See https://github.com/timber/timber/issues/1311 for more info on this behaviour surrounding creation of .php files on WP Engine.
  */
 define('KOKO_ANALYTICS_BUFFER_FILE', rtrim( wp_upload_dir( null, false )['basedir'], '/' ) . '/pageviews-SECRET-NAME.txt');
+define('KOKO_ANALYTICS_BUFFER_FILE_BUSY', 'pageviews-SECRET-NAME-busy.txt');

--- a/code-snippets/wpengine-buffer-file.php
+++ b/code-snippets/wpengine-buffer-file.php
@@ -1,8 +1,11 @@
 <?php
-// WP Engine does not allow the creation of .php files using file_put_content which Koko uses, so we change
-// it to use a file with .txt extension. Make sure to change SECRET-NAME to something unique
-// so that nobody can see your temporary visitor logs. Additionally, make sure this is added to your themes functions.php
-// BEFORE you activate Koko analytics. If Koko has previously been activated, you need to delete the file /koko-analytics-collect.php
-// and then go to the Koko Analytics Settings page to trigger it to install again
-// See https://github.com/timber/timber/issues/1311 for more info on this behaviour on WP Engine
+/**
+ * WP Engine does not allow the creation of .php files using file_put_content which Koko uses, so we change
+ * it to use a file with .txt extension. Make sure to change SECRET-NAME to something unique
+ * so that nobody can see your temporary visitor logs. Additionally, make sure this is added to your themes functions.php
+ * BEFORE you activate Koko analytics. If Koko has previously been activated, you need to delete the file /koko-analytics-collect.php
+ * and then go to the Koko Analytics Settings page to trigger it to install the file again.
+ *
+ * See https://github.com/timber/timber/issues/1311 for more info on this behaviour surrounding creation of .php files on WP Engine.
+ */
 define('KOKO_ANALYTICS_BUFFER_FILE', rtrim( wp_upload_dir( null, false )['basedir'], '/' ) . '/pageviews-SECRET-NAME.txt');

--- a/code-snippets/wpengine-buffer-file.php
+++ b/code-snippets/wpengine-buffer-file.php
@@ -4,7 +4,8 @@
  * it to use a file with .txt extension. Make sure to change SECRET-NAME to something unique
  * so that nobody can see your temporary visitor logs. Additionally, make sure this is added to your themes functions.php
  * BEFORE you activate Koko analytics. If Koko has previously been activated, you need to delete the file /koko-analytics-collect.php
- * and then go to the Koko Analytics Settings page to trigger it to install the file again.
+ * and then go to the Koko Analytics Settings page to trigger it to install the file again. This define() needs to be placed in your
+ * themes function.php or a plugin hooked on 'wp' hook, as it needs access to wp_upload_dir() function.
  *
  * See https://github.com/timber/timber/issues/1311 for more info on this behaviour surrounding creation of .php files on WP Engine.
  */

--- a/code-snippets/wpengine-buffer-file.php
+++ b/code-snippets/wpengine-buffer-file.php
@@ -1,0 +1,8 @@
+<?php
+// WP Engine does not allow the creation of .php files using file_put_content which Koko uses, so we change
+// it to use a file with .txt extension. Make sure to change SECRET-NAME to something unique
+// so that nobody can see your temporary visitor logs. Additionally, make sure this is added to your themes functions.php
+// BEFORE you activate Koko analytics. If Koko has previously been activated, you need to delete the file /koko-analytics-collect.php
+// and then go to the Koko Analytics Settings page to trigger it to install again
+// See https://github.com/timber/timber/issues/1311 for more info on this behaviour on WP Engine
+define('KOKO_ANALYTICS_BUFFER_FILE', rtrim( wp_upload_dir( null, false )['basedir'], '/' ) . '/pageviews-SECRET-NAME.txt');

--- a/src/class-aggregator.php
+++ b/src/class-aggregator.php
@@ -53,8 +53,13 @@ class Aggregator {
 			return;
 		}
 
+		$buffer_file_busy = 'pageviews-busy.php';
+		if ( defined( 'KOKO_ANALYTICS_BUFFER_FILE_BUSY' ) ) {
+			$buffer_file_busy = KOKO_ANALYTICS_BUFFER_FILE_BUSY;
+		}
+
 		// rename file to temporary location so nothing new is written to it while we process it
-		$tmp_filename = dirname( $filename ) . '/pageviews-busy.php';
+		$tmp_filename = dirname( $filename ) . '/' . $buffer_file_busy;
 
 		// if file exists, previous aggregation job is still running or never finished
 		if ( file_exists( $tmp_filename ) ) {


### PR DESCRIPTION
Instructions for how to configure Koko to work with WP Engine. It requires a specific sequence of steps outlined in the attached snippet.