### PR TITLE
Make `trackPageview` accessible from `window.koko_analytics`

### DIFF
--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -111,4 +111,7 @@ window.addEventListener('load', function () {
   }
 
   trackPageview()
+
+  window.koko_analytics.trackPageview = trackPageview;
+
 })

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -112,6 +112,5 @@ window.addEventListener('load', function () {
 
   trackPageview()
 
-  window.koko_analytics.trackPageview = trackPageview;
-
+  window.koko_analytics.trackPageview = trackPageview
 })


### PR DESCRIPTION
This will allow Single Page Apps to manually track a page view, like described in #166 