### PR TITLE
Increase default width for table columns

### DIFF
--- a/assets/src/css/dashboard.css
+++ b/assets/src/css/dashboard.css
@@ -242,7 +242,9 @@ h1.ka-logo,
   border-top: 1px solid #efefef;
   text-align: right;
   padding: 6px 8px;
-  width: 60px;
+  width: 90px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .ka-table th {
   background: #2e363f;


### PR DESCRIPTION
This PR increases the default with of the stats table to prevent overflowing table headings. 

Before EN:
<img width="1336" alt="before-en" src="https://github.com/user-attachments/assets/39bbe622-a337-42e9-b012-43f9514e5fd0">

Before DE:
<img width="1347" alt="before-de" src="https://github.com/user-attachments/assets/9b45a53a-d246-49a9-93d3-3d6170b6db6b">

After EN:
<img width="1334" alt="after-en" src="https://github.com/user-attachments/assets/d4b652fd-7007-4694-b4cc-30481222a9a9">

After DE:
<img width="1341" alt="after-de" src="https://github.com/user-attachments/assets/cf1929e2-448e-4e3a-a4d1-05c109cd11a0">
<img width="674" alt="after-de-2" src="https://github.com/user-attachments/assets/42599573-4d7b-499c-b247-f9d2bb33ccbb">
<sup>(with even longer translation)</sup>
