### PR TITLE
fix: aggregator command should use the new static run method

### DIFF
--- a/src/class-command.php
+++ b/src/class-command.php
@@ -24,8 +24,7 @@ class Command
      */
     public function aggregate($args, $assoc_args)
     {
-        $aggregator = new Aggregator();
-        $aggregator->aggregate();
+        Aggregator::run();
         WP_CLI::success('Stats aggregated.');
     }
 }


### PR DESCRIPTION
This pull request includes a change to the `aggregate` method in the `Command` class to improve the way the `Aggregator` is utilized.

* [`src/class-command.php`](diffhunk://#diff-fa8fa3ae3680307e6ecfe1ef94b8de5fa32d768197e7fb0fb25573e10a25074eL27-R27): Modified the `aggregate` method to use the static `run` method of the `Aggregator` class instead of calling the _deprecated_ (deleted) `aggregate` method on it.