### PR TITLE
Left join on wp_posts to optionally get the title

### DIFF
--- a/src/Stats.php
+++ b/src/Stats.php
@@ -124,9 +124,10 @@ class Stats
         global $wpdb;
 
         $results = $wpdb->get_results($wpdb->prepare(
-            "SELECT p.path, SUM(visitors) AS visitors, SUM(pageviews) AS pageviews
+            "SELECT ifnull(wp.post_title, p.path) AS path, SUM(visitors) AS visitors, SUM(pageviews) AS pageviews
                 FROM {$wpdb->prefix}koko_analytics_post_stats s
                 JOIN {$wpdb->prefix}koko_analytics_paths p ON p.id = s.path_id
+                LEFT JOIN {$wpdb->prefix}posts wp ON s.post_id = wp.ID
                 WHERE s.date >= %s AND s.date <= %s
                 GROUP BY s.path_id
                 ORDER BY pageviews DESC, s.path_id ASC


### PR DESCRIPTION
Following our conversation on https://wordpress.org/support/topic/page-post-titles-lost-in-dashboard/, I suggest this change that allows to get the post title if it exists. It seems to work correctly on my website :)
